### PR TITLE
added fan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,27 @@ This is what handles the accessory logic like syncing states between HomeKit and
           serial_number: "42424242"
           fw_rev: "0.16.2"
   ```
+ - **fan** (Optional): Array of Fan Entities
+   - **id** (Required, [Fan](https://esphome.io/components/fan/)): Id of the fan entity
+   - **meta** (Optional): Accessory information
+     - **name** (Optional, string): Name of the accessory, defaults to name of the entity
+     - **model** (Optional, string): Model name for the accessory
+     - **manufacturer** (Optional, string): Manufacturer name for the accessory
+     - **serial_number** (Optional, string): Serial number for the accessory, defaults to internal object id
+     - **fw_rev** (Optional, string): Firmware revision for the accessory
 
+   Example:
+   ```yaml
+   homekit:
+     fan:
+       - id: my_fan
+         meta:
+           name: "Living Room Fan"
+           manufacturer: "AMICI&CO"
+           model: "VENTUS"
+           serial_number: "42424242"
+           fw_rev: "0.16.2"
+   ```
 ## 4. HomeKey
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See [Components](#3-components) for documentation.
 | Lock   | Lock/Unlock                                                           | Homekey can be enabled but only the `pn532_spi` component is supported to be used with it                                                           |
 | Switch | On/Off                                                                |                                                                                                                                                     |
 | Sensor | Temperature, Humidity, Illuminance, Air Quality, CO2, CO, PM10, PM2.5 | `device_class` property has to be declared with the sensor type as per HASS [docs](https://www.home-assistant.io/integrations/sensor/#device-class) |
+| Fan    | On/Off                                                                |                                                                                                                                                     |
 
 ## 2. Prerequisites
 

--- a/components/homekit/HAPAccessory.cpp
+++ b/components/homekit/HAPAccessory.cpp
@@ -22,6 +22,11 @@ namespace esphome
         v->setup();
       }
       #endif
+      #ifdef USE_FAN
+      for (const auto v : fans) {
+        v->setup();
+      }
+      #endif
       #ifdef USE_SWITCH
       for (const auto v : switches) {
         v->setup();
@@ -48,6 +53,9 @@ namespace esphome
       #ifdef USE_SENSOR
       ESP_LOGCONFIG(TAG, "Sensor HK Entities: %d", sensors.size());
       #endif
+      #ifdef USE_FAN
+      ESP_LOGCONFIG(TAG, "Fan HK Entities: %d", fans.size());
+      #endif
       #ifdef USE_SWITCH
       ESP_LOGCONFIG(TAG, "Switch HK Entities: %d", switches.size());
       #endif
@@ -70,6 +78,12 @@ namespace esphome
     }
     void HAPAccessory::set_hk_hw_finish(HKFinish color) {
       hkHwFinish = color;
+    }
+    #endif
+    #ifdef USE_FAN
+    FanEntity* HAPAccessory::add_fan(fan::Fan* fanPtr) {
+      fans.push_back(new FanEntity(fanPtr));
+      return fans.back();
     }
     #endif
     #ifdef USE_SWITCH

--- a/components/homekit/HAPAccessory.h
+++ b/components/homekit/HAPAccessory.h
@@ -10,6 +10,9 @@
 #ifdef USE_LOCK
 #include "lock.h"
 #endif
+#ifdef USE_FAN
+#include "fan.hpp"
+#endif
 #ifdef USE_SWITCH
 #include "switch.hpp"
 #endif
@@ -46,6 +49,10 @@ namespace esphome
       #ifdef USE_HOMEKEY
       void set_nfc_ctx(pn532::PN532* nfcCtx);
       void set_hk_hw_finish(HKFinish color);
+      #endif
+      #ifdef USE_FAN
+      std::vector<FanEntity*> fans;
+      FanEntity* add_fan(fan::Fan* fanPtr);
       #endif
       #ifdef USE_SWITCH
       std::vector<SwitchEntity*> switches;

--- a/components/homekit/__init__.py
+++ b/components/homekit/__init__.py
@@ -128,7 +128,7 @@ async def to_code(config):
                 cg.add(lock_entity.setInfo(info_temp))
     if "fan" in config:
         for l in config["fan"]:
-            fan_entity = cg.Pvariable(ID(f"{l['id'].id}_hk_switch_entity", type=FanEntity), var.add_fan(await cg.get_variable(l['id'])))
+            fan_entity = cg.Pvariable(ID(f"{l['id'].id}_hk_fan_entity", type=FanEntity), var.add_fan(await cg.get_variable(l['id'])))
             if "meta" in l:
                 info_temp = []
                 for m in l["meta"]:

--- a/components/homekit/__init__.py
+++ b/components/homekit/__init__.py
@@ -1,7 +1,7 @@
 from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import mdns, wifi, light, lock, sensor, switch, climate, pn532
+from esphome.components import mdns, wifi, light, lock, sensor, switch, climate, pn532, fan
 from esphome.const import PLATFORM_ESP32, CONF_ID, CONF_TRIGGER_ID
 from esphome.core import ID, Lambda
 from esphome.components.esp32 import add_idf_component
@@ -21,6 +21,7 @@ LightEntity = homekit_ns.class_('LightEntity')
 SensorEntity = homekit_ns.class_('SensorEntity')
 SwitchEntity = homekit_ns.class_('SwitchEntity')
 LockEntity = homekit_ns.class_('LockEntity')
+FanEntity = homekit_ns.class_('FanEntity')
 OnHkSuccessTrigger = homekit_ns.class_(
     "HKAuthTrigger", automation.Trigger.template(cg.std_string, cg.std_string)
 )
@@ -71,6 +72,7 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
         cv.Optional("meta") : ACCESSORY_INFORMATION
         }),
     cv.Optional("sensor"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(sensor.Sensor), cv.Optional("temp_units", default="CELSIUS") : cv.enum(TEMP_UNITS), cv.Optional("meta") : ACCESSORY_INFORMATION}),
+    cv.Optional("fan"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(fan.Fan), cv.Optional("meta") : ACCESSORY_INFORMATION}),
     cv.Optional("switch"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(switch.Switch), cv.Optional("meta") : ACCESSORY_INFORMATION}),
     cv.Optional("climate"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(climate.Climate), cv.Optional("meta") : ACCESSORY_INFORMATION}),
 }).extend(cv.COMPONENT_SCHEMA),
@@ -124,6 +126,14 @@ async def to_code(config):
                 for m in l["meta"]:
                     info_temp.append([ACC_INFO[m], l["meta"][m]])
                 cg.add(lock_entity.setInfo(info_temp))
+    if "fan" in config:
+        for l in config["fan"]:
+            fan_entity = cg.Pvariable(ID(f"{l['id'].id}_hk_switch_entity", type=FanEntity), var.add_fan(await cg.get_variable(l['id'])))
+            if "meta" in l:
+                info_temp = []
+                for m in l["meta"]:
+                    info_temp.append([ACC_INFO[m], l["meta"][m]])
+                cg.add(fan_entity.setInfo(info_temp))
     if "switch" in config:
         for l in config["switch"]:
             switch_entity = cg.Pvariable(ID(f"{l['id'].id}_hk_switch_entity", type=SwitchEntity), var.add_switch(await cg.get_variable(l['id'])))

--- a/components/homekit/fan.hpp
+++ b/components/homekit/fan.hpp
@@ -1,0 +1,111 @@
+#pragma once
+#include <esphome/core/defines.h>
+#ifdef USE_FAN
+#include <esphome/core/application.h>
+#include <hap.h>
+#include <hap_apple_servs.h>
+#include <hap_apple_chars.h>
+#include <map>
+
+namespace esphome
+{
+  namespace homekit
+  {
+    class FanEntity
+    {
+    private:
+      static constexpr const char* TAG = "FanEntity";
+      std::map<AInfo, const char*> accessory_info = {{NAME, NULL}, {MODEL, "HAP-FAN"}, {SN, NULL}, {MANUFACTURER, "rednblkx"}, {FW_REV, "0.1"}};
+      fan::Fan* fanPtr;
+      static int fanwrite(hap_write_data_t write_data[], int count, void* serv_priv, void* write_priv) {
+        fan::Fan* fanPtr = (fan::Fan*)serv_priv;
+        ESP_LOGD(TAG, "Write called for Accessory %s (%s)", std::to_string(fanPtr->get_object_id_hash()).c_str(), fanPtr->get_name().c_str());
+        int i, ret = HAP_SUCCESS;
+        hap_write_data_t* write;
+        for (i = 0; i < count; i++) {
+          write = &write_data[i];
+          if (!strcmp(hap_char_get_type_uuid(write->hc), HAP_CHAR_UUID_ON)) {
+            ESP_LOGD(TAG, "Received Write for fan '%s' -> %s", fanPtr->get_name().c_str(), write->val.b ? "On" : "Off");
+            ESP_LOGD(TAG, "[STATE] CURRENT STATE: %d", fanPtr->state);
+            fanPtr->make_call().set_state(write->val.b).perform();
+            hap_char_update_val(write->hc, &(write->val));
+            *(write->status) = HAP_STATUS_SUCCESS;
+          }
+          else {
+            *(write->status) = HAP_STATUS_RES_ABSENT;
+          }
+        }
+        return ret;
+      }
+      void on_fanupdate(fan::Fan* obj) {
+        ESP_LOGD(TAG, "%s state: %s", obj->get_name().c_str(), ONOFF(obj->state));
+        hap_acc_t* acc = hap_acc_get_by_aid(hap_get_unique_aid(std::to_string(obj->get_object_id_hash()).c_str()));
+        if (acc) {
+          hap_serv_t* hs = hap_acc_get_serv_by_uuid(acc, HAP_SERV_UUID_FAN);
+          hap_char_t* on_char = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_ON);
+          hap_val_t state;
+          state.b = !!obj->state;
+          hap_char_update_val(on_char, &state);
+        }
+      }
+      static int acc_identify(hap_acc_t* ha) {
+        ESP_LOGI(TAG, "Accessory identified");
+        return HAP_SUCCESS;
+      }
+    public:
+      FanEntity(fan::Fan* fanPtr) : fanPtr(fanPtr) {}
+      void setInfo(std::map<AInfo, const char*> info) {
+        std::map<AInfo, const char*> merged_info;
+        merged_info.merge(info);
+        merged_info.merge(this->accessory_info);
+        this->accessory_info.swap(merged_info);
+      }
+      void setup() {
+        hap_acc_cfg_t acc_cfg = {
+            .model = strdup(accessory_info[MODEL]),
+            .manufacturer = strdup(accessory_info[MANUFACTURER]),
+            .fw_rev = strdup(accessory_info[FW_REV]),
+            .hw_rev = NULL,
+            .pv = strdup("1.1.0"),
+            .cid = HAP_CID_BRIDGE,
+            .identify_routine = acc_identify,
+        };
+        hap_acc_t* accessory = nullptr;
+        hap_serv_t* service = nullptr;
+        std::string accessory_name = fanPtr->get_name();
+        if (accessory_info[NAME] == NULL) {
+          acc_cfg.name = strdup(accessory_name.c_str());
+        }
+        else {
+          acc_cfg.name = strdup(accessory_info[NAME]);
+        }
+        if (accessory_info[SN] == NULL) {
+          acc_cfg.serial_num = strdup(std::to_string(fanPtr->get_object_id_hash()).c_str());
+        }
+        else {
+          acc_cfg.serial_num = strdup(accessory_info[SN]);
+        }
+        /* Create accessory object */
+        accessory = hap_acc_create(&acc_cfg);
+        /* Create the fan Service. */
+        service = hap_serv_fan_create(fanPtr->state);
+
+        ESP_LOGD(TAG, "ID HASH: %lu", fanPtr->get_object_id_hash());
+        hap_serv_set_priv(service, fanPtr);
+
+        /* Set the write callback for the service */
+        hap_serv_set_write_cb(service, fanwrite);
+
+        /* Add the Fan Service to the Accessory Object */
+        hap_acc_add_serv(accessory, service);
+
+        /* Add the Accessory to the HomeKit Database */
+        hap_add_bridged_accessory(accessory, hap_get_unique_aid(std::to_string(fanPtr->get_object_id_hash()).c_str()));
+        if (!fanPtr->is_internal())
+          fanPtr->add_on_state_callback([this]() { this->on_fanupdate(fanPtr); });
+        ESP_LOGI(TAG, "Fan '%s' linked to HomeKit", accessory_name.c_str());
+      }
+    };
+  }
+}
+#endif

--- a/fan-c3.yaml
+++ b/fan-c3.yaml
@@ -1,0 +1,47 @@
+esphome:
+  name: fan_test
+
+esp32:
+  board: esp32-c3-devkitm-1
+  flash_size: 4MB
+  framework:
+    type: esp-idf
+    version: 5.2.1
+    platform_version: 6.7.0
+    sdkconfig_options:
+      CONFIG_COMPILER_OPTIMIZATION_SIZE: y
+      CONFIG_LWIP_MAX_SOCKETS: "16"
+      CONFIG_MBEDTLS_HKDF_C: y
+
+external_components:
+  source: github://rednblkx/HAP-ESPHome@main
+  refresh: 0s
+
+homekit_base:
+  setup_code: '159-35-728'
+
+homekit:
+  fan:
+    - id: fan_1
+      meta:
+        name: "My Fan"
+
+fan:
+  - platform: binary
+    id: fan_1
+    name: "My Fan"
+    output: fan_output
+
+output:
+  - platform: gpio
+    id: fan_output
+    pin:
+      number: GPIO8
+      inverted: true
+
+logger:
+  level: DEBUG
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password


### PR DESCRIPTION
added fan support. tested on a c3 supermini and wroom 32e. bridged with an appletv and tested voice controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for fan entities in the HomeKit integration.
	- Added functionality for managing fan entities, including setup and logging.
	- Enhanced configuration options for fan control, including setup for a new fan entity.
	- Added a new entity type "Fan" with On/Off attributes in the documentation.
- **Documentation**
	- Updated configuration schema to include fan settings.
	- Expanded README to detail the new Fan entity and its configuration variables.
- **Chores**
	- Created a new YAML configuration file for ESP32-based fan control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->