### PR TITLE
added cold warm white support

### DIFF
--- a/components/homekit/light.hpp
+++ b/components/homekit/light.hpp
@@ -90,7 +90,7 @@ namespace esphome
       void on_light_update(light::LightState* obj) {
         bool rgb = obj->current_values.get_color_mode() & light::ColorCapability::RGB;
         bool level = obj->get_traits().supports_color_capability(light::ColorCapability::BRIGHTNESS);
-        bool temperature = obj->current_values.get_color_mode() & light::ColorCapability::COLOR_TEMPERATURE;
+        bool temperature = obj->current_values.get_color_mode() & (light::ColorCapability::COLOR_TEMPERATURE | light::ColorCapability::COLD_WARM_WHITE);
         if (rgb) {
           ESP_LOGD(TAG, "%s RED: %.2f, GREEN: %.2f, BLUE: %.2f", obj->get_name().c_str(), obj->current_values.get_red(), obj->current_values.get_green(), obj->current_values.get_blue());
         }
@@ -181,7 +181,8 @@ namespace esphome
           hap_serv_add_char(service, hap_char_hue_create(hue));
           hap_serv_add_char(service, hap_char_saturation_create(saturation * 100));
         }
-        if (lightPtr->get_traits().supports_color_capability(light::ColorCapability::COLOR_TEMPERATURE)) {
+        if (lightPtr->get_traits().supports_color_capability(light::ColorCapability::COLOR_TEMPERATURE) ||
+            lightPtr->get_traits().supports_color_capability(light::ColorCapability::COLD_WARM_WHITE)) {
           hap_serv_add_char(service, hap_char_color_temperature_create(lightPtr->current_values.get_color_temperature()));
         }
         ESP_LOGD(TAG, "ID HASH: %lu", lightPtr->get_object_id_hash());


### PR DESCRIPTION
added cold warm white to traits for additional devices. tested with the ble_adv_controller component from aronsky/esphome-components, allowing the lights to change color through the homekit app. c3 supermini controls four ble lights with identical controllers.

```
homekit:
  light:
    - id: ble_light_1
      meta:
        name: "Small Bedroom Ceiling Light"

light:
  - platform: ble_adv_controller
    ble_adv_controller_id: my_controller_1
    id: ble_light_1
    name: Small Bedroom
    internal: false
    restore_mode: RESTORE_DEFAULT_OFF
    separate_dim_cct: false

ble_adv_controller:
  - id: my_controller_1
    internal: true
    show_config: true
    encoding: lampsmart_pro
```

```
20241212-15:26:12 blecon-530770/light/small_bedroom/state {"color_mode":"cwww","state":"ON","brightness":7,"color":{"c":255,"w":0}}
20241212-15:26:12 blecon-530770/debug [D][ble_adv_light:053]: BleAdvLight::write_state - Switch ON
20241212-15:26:12 blecon-530770/debug [D][lampsmart_pro - v3:102]: UUID: '0x********', index: 0, tx: 12, cmd: '0x10', args: [0,0,0,0]
20241212-15:26:12 blecon-530770/debug [D][ble_adv_light:084]: Updating Cold: 4%, Warm: 0%
20241212-15:26:12 blecon-530770/debug [D][lampsmart_pro - v3:102]: UUID: '0x********', index: 0, tx: 13, cmd: '0x21', args: [0,0,10,0]
20241212-15:26:12 blecon-530770/debug [D][LightEntity:026][httpd]: Write called for Accessory ******** (Small Bedroom)
20241212-15:26:12 blecon-530770/debug [D][LightEntity:039][httpd]: Received Write for Light 'Small Bedroom' Level: 12
20241212-15:26:13 blecon-530770/debug [D][LightEntity:040][httpd]: [LEVEL] CURRENT BRIGHTNESS: 3
20241212-15:26:13 blecon-530770/debug [D][LightEntity:041][httpd]: TARGET BRIGHTNESS: 12
20241212-15:26:13 blecon-530770/debug [D][light:036][httpd]: 'Small Bedroom' Setting:
20241212-15:26:13 blecon-530770/debug [D][light:051][httpd]:   Brightness: 12%
20241212-15:26:13 blecon-530770/debug [D][LightEntity:101][httpd]: Small Bedroom state: 100 brightness: 12

20241212-15:26:13 blecon-530770/light/small_bedroom/state {"color_mode":"cwww","state":"ON","brightness":30,"color":{"c":255,"w":0}}
20241212-15:26:13 blecon-530770/debug [D][ble_adv_light:084]: Updating Cold: 13%, Warm: 0%

20241212-15:26:15 blecon-530770/light/small_bedroom/state {"color_mode":"cwww","state":"ON","brightness":30,"color":{"c":0,"w":255}}
20241212-15:26:15 blecon-530770/debug [D][ble_adv_light:084]: Updating Cold: 0%, Warm: 13%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for color temperature capabilities in light controls, accommodating both color temperature and cold/warm white options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->