### PR TITLE
Add a on_hk_start trigger to measure hk latency

### DIFF
--- a/components/homekit/__init__.py
+++ b/components/homekit/__init__.py
@@ -28,6 +28,9 @@ OnHkSuccessTrigger = homekit_ns.class_(
 OnHkFailTrigger = homekit_ns.class_(
     "HKFailTrigger", automation.Trigger.template()
 )
+OnHkStartTrigger = homekit_ns.class_(
+    "HKStartTrigger", automation.Trigger.template()
+)
 CONF_IDENTIFY_LAMBDA = "identify_fn"
 
 TEMP_UNITS = {
@@ -66,6 +69,11 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
         cv.Optional("on_hk_fail"): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnHkFailTrigger),
+            }
+        ),
+        cv.Optional("on_hk_start"): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnHkStartTrigger),
             }
         ),
         cv.Optional("hk_hw_finish", default="BLACK") : cv.enum(HK_HW_FINISH),
@@ -120,6 +128,10 @@ async def to_code(config):
                 for conf in l.get("on_hk_fail", []):
                     trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
                     cg.add(lock_entity.register_onhkfail_trigger(trigger))
+                    await automation.build_automation(trigger, [], conf)
+                for conf in l.get("on_hk_start", []):
+                    trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
+                    cg.add(lock_entity.register_onhkstart_trigger(trigger))
                     await automation.build_automation(trigger, [], conf)
             if "meta" in l:
                 info_temp = []

--- a/components/homekit/automation.cpp
+++ b/components/homekit/automation.cpp
@@ -10,5 +10,8 @@ namespace esphome
     void HKFailTrigger::process() {
       this->trigger();
     }
+    void HKStartTrigger::process() {
+      this->trigger();
+    }
   }
 }

--- a/components/homekit/automation.h
+++ b/components/homekit/automation.h
@@ -16,5 +16,10 @@ namespace esphome
     public:
       void process();
     };
+    class HKStartTrigger : public Trigger<>
+    {
+    public:
+      void process();
+    };
   }
 }

--- a/components/homekit/lock.cpp
+++ b/components/homekit/lock.cpp
@@ -256,6 +256,9 @@ namespace esphome
       void LockEntity::register_onhkfail_trigger(HKFailTrigger* trig) {
         triggers_onhk_fail_.push_back(trig);
       }
+      void LockEntity::register_onhkstart_trigger(HKStartTrigger* trig) {
+        triggers_onhk_start_.push_back(trig);
+      }
       void LockEntity::set_hk_hw_finish(HKFinish color) {
         ESP_LOGI(TAG, "SELECTED HK FINISH: %s", intToFinishString(color).c_str());
         hap_tlv8_val_t tlvData = {
@@ -284,6 +287,10 @@ namespace esphome
           if (versions.size() > 0) {
             ESP_LOGD(TAG, "HK SUPPORTED VERSIONS: %s", format_hex_pretty(versions).c_str());
             if (versions.data()[versions.size() - 2] == 0x90 && versions.data()[versions.size() - 1] == 0x0) {
+              for (auto &&t : triggers_onhk_start_)
+              {
+                t->process();
+              }
               HKAuthenticationContext authCtx(lambda, readerData, savedHKdata);
               auto authResult = authCtx.authenticate(KeyFlow(kFlowFAST));
               if (std::get<0>(authResult).size() > 0 && std::get<2>(authResult) != kFlowFailed) {

--- a/components/homekit/lock.h
+++ b/components/homekit/lock.h
@@ -45,6 +45,7 @@ namespace esphome
       };
       std::vector<HKAuthTrigger *> triggers_onhk_;
       std::vector<HKFailTrigger *> triggers_onhk_fail_;
+      std::vector<HKStartTrigger *> triggers_onhk_start_;
       static int nfcAccess_write(hap_write_data_t write_data[], int count, void* serv_priv, void* write_priv);
       static void hap_event_handler(hap_event_t event, void* data);
       #endif
@@ -62,6 +63,7 @@ namespace esphome
       void set_hk_hw_finish(HKFinish color);
       void register_onhk_trigger(HKAuthTrigger* trig);
       void register_onhkfail_trigger(HKFailTrigger* trig);
+      void register_onhkstart_trigger(HKStartTrigger* trig);
       #endif
     };
   }


### PR DESCRIPTION
I was tracking down some latency in a lock I built with this project and found it helpful to add a trigger before the homekit handshake. I imagine this could be generally useful if someone wanted to flash a light or provide some other feedback that the nfc read had completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new automation trigger that activates when HomeKit interactions begin, allowing users to seamlessly integrate start events into their automation workflows.
	- Enhanced event handling for HomeKit, providing improved responsiveness and flexibility in configuring automation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->