### PR TITLE
chore: merge pn532 upstream changes

### DIFF
--- a/components/pn532/__init__.py
+++ b/components/pn532/__init__.py
@@ -19,10 +19,6 @@ CONF_PN532_ID = "pn532_id"
 pn532_ns = cg.esphome_ns.namespace("pn532")
 PN532 = pn532_ns.class_("PN532", cg.PollingComponent)
 
-PN532OnFinishedWriteTrigger = pn532_ns.class_(
-    "PN532OnFinishedWriteTrigger", automation.Trigger.template()
-)
-
 PN532IsWritingCondition = pn532_ns.class_(
     "PN532IsWritingCondition", automation.Condition
 )
@@ -35,13 +31,7 @@ PN532_SCHEMA = cv.Schema(
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(nfc.NfcOnTagTrigger),
             }
         ),
-        cv.Optional(CONF_ON_FINISHED_WRITE): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                    PN532OnFinishedWriteTrigger
-                ),
-            }
-        ),
+        cv.Optional(CONF_ON_FINISHED_WRITE): automation.validate_automation({}),
         cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(nfc.NfcOnTagTrigger),
@@ -57,6 +47,13 @@ def CONFIG_SCHEMA(conf):
             "This component has been moved in 1.16, please see the docs for updated "
             "instructions. https://esphome.io/components/binary_sensor/pn532/"
         )
+
+
+_CALLBACK_AUTOMATIONS = (
+    automation.CallbackAutomation(
+        CONF_ON_FINISHED_WRITE, "add_on_finished_write_callback"
+    ),
+)
 
 
 async def setup_pn532(var, config):
@@ -76,9 +73,7 @@ async def setup_pn532(var, config):
             trigger, [(cg.std_string, "x"), (nfc.NfcTag, "tag")], conf
         )
 
-    for conf in config.get(CONF_ON_FINISHED_WRITE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+    await automation.build_callback_automations(var, config, _CALLBACK_AUTOMATIONS)
 
 
 @automation.register_condition(

--- a/components/pn532/pn532.cpp
+++ b/components/pn532/pn532.cpp
@@ -33,10 +33,7 @@ void PN532::setup() {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG,
-           "Found chip PN5%02X\n"
-           "Firmware ver. %d.%d",
-           version_data[0], version_data[1], version_data[2]);
+  ESP_LOGD(TAG, "Found chip PN5%02X, Firmware v%d.%d", version_data[0], version_data[1], version_data[2]);
 
   if (!this->write_command_({
           PN532_COMMAND_SAMCONFIGURATION,
@@ -444,13 +441,13 @@ void PN532::send_nack_() {
 enum PN532ReadReady PN532::read_ready_(bool block) {
   if (this->rd_ready_ == READY) {
     if (block) {
-      this->rd_start_time_ = 0;
+      this->rd_start_time_.reset();
       this->rd_ready_ = WOULDBLOCK;
     }
     return READY;
   }
 
-  if (!this->rd_start_time_) {
+  if (!this->rd_start_time_.has_value()) {
     this->rd_start_time_ = millis();
   }
 
@@ -460,7 +457,7 @@ enum PN532ReadReady PN532::read_ready_(bool block) {
       break;
     }
 
-    if (millis() - this->rd_start_time_ > 100) {
+    if (millis() - *this->rd_start_time_ > 100) {
       ESP_LOGV(TAG, "Timed out waiting for readiness from PN532!");
       this->rd_ready_ = TIMEOUT;
       break;
@@ -476,7 +473,7 @@ enum PN532ReadReady PN532::read_ready_(bool block) {
 
   auto rdy = this->rd_ready_;
   if (block || rdy == TIMEOUT) {
-    this->rd_start_time_ = 0;
+    this->rd_start_time_.reset();
     this->rd_ready_ = WOULDBLOCK;
   }
   return rdy;

--- a/components/pn532/pn532.h
+++ b/components/pn532/pn532.h
@@ -45,15 +45,16 @@ class PN532 : public PollingComponent {
   void register_ontag_trigger(nfc::NfcOnTagTrigger *trig) { this->triggers_ontag_.push_back(trig); }
   void register_ontagremoved_trigger(nfc::NfcOnTagTrigger *trig) { this->triggers_ontagremoved_.push_back(trig); }
 
-  void add_on_finished_write_callback(std::function<void()> callback) {
-    this->on_finished_write_callback_.add(std::move(callback));
+  template<typename F> void add_on_finished_write_callback(F &&callback) {
+    this->on_finished_write_callback_.add(std::forward<F>(callback));
   }
+
+  bool is_writing() { return this->next_task_ != READ; };
 
   std::vector<uint8_t> inDataExchange(const std::vector<uint8_t>& data);
 
   void set_ecp_frame(std::vector<uint8_t>& frame) { ecp_frame = frame; };
 
-  bool is_writing() { return this->next_task_ != READ; };
 
   void read_mode();
   void clean_mode();
@@ -110,7 +111,7 @@ class PN532 : public PollingComponent {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
   nfc::NfcTagUid current_uid_;
   nfc::NdefMessage *next_task_message_to_write_;
-  uint32_t rd_start_time_{0};
+  optional<uint32_t> rd_start_time_{};
   enum PN532ReadReady rd_ready_ { WOULDBLOCK };
   enum NfcTask {
     READ = 0,
@@ -142,13 +143,6 @@ class PN532BinarySensor : public binary_sensor::BinarySensor {
  protected:
   nfc::NfcTagUid uid_;
   bool found_{false};
-};
-
-class PN532OnFinishedWriteTrigger : public Trigger<> {
- public:
-  explicit PN532OnFinishedWriteTrigger(PN532 *parent) {
-    parent->add_on_finished_write_callback([this]() { this->trigger(); });
-  }
 };
 
 template<typename... Ts> class PN532IsWritingCondition : public Condition<Ts...>, public Parented<PN532> {

--- a/components/pn532/pn532_mifare_ultralight.cpp
+++ b/components/pn532/pn532_mifare_ultralight.cpp
@@ -99,7 +99,7 @@ bool PN532::find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6
                                          uint8_t &message_start_index) {
   const uint8_t p4_offset = nfc::MIFARE_ULTRALIGHT_PAGE_SIZE;  // page 4 will begin 4 bytes into the vector
 
-  if (!(page_3_to_6.size() > p4_offset + 5)) {
+  if (!(page_3_to_6.size() > p4_offset + 6)) {
     return false;
   }
 
@@ -134,7 +134,7 @@ bool PN532::write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *
   } else {
     encoded.insert(encoded.begin() + 1, 0xFF);
     encoded.insert(encoded.begin() + 2, (message_length >> 8) & 0xFF);
-    encoded.insert(encoded.begin() + 2, message_length & 0xFF);
+    encoded.insert(encoded.begin() + 3, message_length & 0xFF);
   }
   encoded.push_back(0xFE);
 

--- a/components/pn532_spi/pn532_spi.cpp
+++ b/components/pn532_spi/pn532_spi.cpp
@@ -88,9 +88,10 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
 #endif
   ESP_LOGV(TAG, "Header data: %s", format_hex_pretty_to(hex_buf, sizeof(hex_buf), header.data(), header.size()));
 
-  if (header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF) {
+  if (header[0] != 0x00 || header[1] != 0x00 || header[2] != 0xFF) {
     // invalid packet
     ESP_LOGV(TAG, "read data invalid preamble!");
+    this->disable();
     return false;
   }
 
@@ -106,12 +107,17 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
 
   if (!valid_header && !error_frame && !extended_frame) {
     ESP_LOGV(TAG, "read data invalid header!");
+    this->disable();
     return false;
   }
 
-
-  // full length of message, including command response
+  // full length of message, including command response (minimum 2: TFI + command response)
   uint16_t full_len = header[3];
+  if (full_len < 2) {                         
+    ESP_LOGV(TAG, "read data has no payload");
+    this->disable();                          
+    return false;                             
+  }
   if (extended_frame) {
     ESP_LOGV(TAG, "Abnormal length and checksum, possible Extended Frame");
     header.resize(10);
@@ -126,8 +132,6 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
   }
   // length of data, excluding command response
   uint16_t len = full_len - 1;
-  if (full_len == 0)
-    len = 0;
 
   ESP_LOGV(TAG, "Reading response of length %d", len);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized write-completion handling to callback-based automations for more reliable NFC write workflows.
  * Improved read-timeout tracking for NFC readers to reduce spurious timeouts and improve stability.

* **Bug Fixes**
  * Strengthened SPI NFC packet validation and ensured device is properly disabled on invalid reads to avoid corrupted exchanges.
  * Tightened MIFARE Ultralight NDEF bounds and byte-layout handling for more reliable tag read/write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->