### PR TITLE
Update to only_on_esp32

### DIFF
--- a/components/homekit/__init__.py
+++ b/components/homekit/__init__.py
@@ -76,8 +76,7 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
     cv.Optional("switch"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(switch.Switch), cv.Optional("meta") : ACCESSORY_INFORMATION}),
     cv.Optional("climate"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(climate.Climate), cv.Optional("meta") : ACCESSORY_INFORMATION}),
 }).extend(cv.COMPONENT_SCHEMA),
-cv.only_on([PLATFORM_ESP32]),
-cv.only_with_esp_idf)
+cv.only_on_esp32)
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/components/homekit_base/__init__.py
+++ b/components/homekit_base/__init__.py
@@ -43,8 +43,7 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
     cv.Optional("setup_code", default="159-35-728"): hk_setup_code,
     cv.Optional("setup_id", default="ES32"): cv.All(cv.string_strict,cv.Upper,cv.Length(min=4, max=4, msg="Setup ID has to be a 4 character long alpha numeric string (with capital letters)"))
 }).extend(cv.COMPONENT_SCHEMA),
-cv.only_on([PLATFORM_ESP32]),
-cv.only_with_esp_idf)
+cv.only_on_esp32)
 
 async def to_code(config):
     add_idf_component(


### PR DESCRIPTION
This updates based on the depreciation which is happening by 2026.6 for ESPHome.

https://developers.esphome.io/blog/2026/01/12/use_esp_idf-deprecated-in-favor-of-use_esp32/

It then removes the compilation warnings around this, and moves everything into one section for needing ESP32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration schema constraints for HomeKit components to improve code maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rednblkx/HAP-ESPHome/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->