### PR TITLE
Replace deprecated method get_device_class() with get_device_class_to()

### DIFF
--- a/components/homekit/sensor.hpp
+++ b/components/homekit/sensor.hpp
@@ -60,8 +60,8 @@ namespace esphome
       SensorEntity(sensor::Sensor* sensorPtr) : HAPEntity({{MODEL, "HAP-SENSOR"}}), sensorPtr(sensorPtr) {}
       void setup() {
         hap_serv_t* service = nullptr;
-
-        std::string device_class = sensorPtr->get_device_class();
+        char dc_buf[MAX_DEVICE_CLASS_LENGTH];
+        std::string device_class = sensorPtr->get_device_class_to(dc_buf);
         if (std::equal(device_class.begin(), device_class.end(), strdup("temperature"))) {
           service = hap_serv_temperature_sensor_create(sensorPtr->state);
         }


### PR DESCRIPTION
ESPHome 2026.9.0 will remove get_device_class(), and suggest use get_device_class_to() instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor setup compatibility by correctly handling device class information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->