### PR TITLE
Add cover entity support mapped to HomeKit Garage Door Opener

### DIFF
--- a/components/homekit/HAPAccessory.cpp
+++ b/components/homekit/HAPAccessory.cpp
@@ -37,6 +37,11 @@ namespace esphome
         v->setup();
       }
       #endif
+      #ifdef USE_COVER
+      for (const auto v : covers) {
+        v->setup();
+      }
+      #endif
       #ifdef USE_CLIMATE
       for (const auto v : climates) {
         v->setup();
@@ -58,6 +63,9 @@ namespace esphome
       #endif
       #ifdef USE_SWITCH
       ESP_LOGCONFIG(TAG, "Switch HK Entities: %d", switches.size());
+      #endif
+      #ifdef USE_COVER
+      ESP_LOGCONFIG(TAG, "Cover HK Entities: %d", covers.size());
       #endif
     }
     #ifdef USE_LIGHT
@@ -96,6 +104,12 @@ namespace esphome
     SensorEntity* HAPAccessory::add_sensor(sensor::Sensor* sensorPtr, TemperatureUnits units) {
       sensors.push_back(new SensorEntity(sensorPtr));
       return sensors.back();
+    }
+    #endif
+    #ifdef USE_COVER
+    CoverEntity* HAPAccessory::add_cover(cover::Cover* coverPtr) {
+      covers.push_back(new CoverEntity(coverPtr));
+      return covers.back();
     }
     #endif
     #ifdef USE_CLIMATE

--- a/components/homekit/HAPAccessory.h
+++ b/components/homekit/HAPAccessory.h
@@ -19,6 +19,9 @@
 #ifdef USE_SENSOR
 #include "sensor.hpp"
 #endif
+#ifdef USE_COVER
+#include "cover.hpp"
+#endif
 #ifdef USE_CLIMATE
 #include "climate.hpp"
 #endif
@@ -61,6 +64,10 @@ namespace esphome
       #ifdef USE_SENSOR
       std::vector<SensorEntity*> sensors;
       SensorEntity* add_sensor(sensor::Sensor* sensorPtr, TemperatureUnits units);
+      #endif
+      #ifdef USE_COVER
+      std::vector<CoverEntity*> covers;
+      CoverEntity* add_cover(cover::Cover* coverPtr);
       #endif
       #ifdef USE_CLIMATE
       std::vector<ClimateEntity*> climates;

--- a/components/homekit/__init__.py
+++ b/components/homekit/__init__.py
@@ -1,7 +1,7 @@
 from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import mdns, wifi, light, lock, sensor, switch, climate, pn532, fan
+from esphome.components import mdns, wifi, light, lock, sensor, switch, climate, pn532, fan, cover
 from esphome.const import PLATFORM_ESP32, CONF_ID, CONF_TRIGGER_ID
 from esphome.core import ID, Lambda
 from esphome.components.esp32 import add_idf_component
@@ -22,6 +22,7 @@ SensorEntity = homekit_ns.class_('SensorEntity')
 SwitchEntity = homekit_ns.class_('SwitchEntity')
 LockEntity = homekit_ns.class_('LockEntity')
 FanEntity = homekit_ns.class_('FanEntity')
+CoverEntity = homekit_ns.class_('CoverEntity')
 OnHkSuccessTrigger = homekit_ns.class_(
     "HKAuthTrigger", automation.Trigger.template(cg.std_string, cg.std_string)
 )
@@ -74,6 +75,7 @@ CONFIG_SCHEMA = cv.All(cv.Schema({
     cv.Optional("sensor"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(sensor.Sensor), cv.Optional("temp_units", default="CELSIUS") : cv.enum(TEMP_UNITS), cv.Optional("meta") : ACCESSORY_INFORMATION}),
     cv.Optional("fan"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(fan.Fan), cv.Optional("meta") : ACCESSORY_INFORMATION}),
     cv.Optional("switch"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(switch.Switch), cv.Optional("meta") : ACCESSORY_INFORMATION}),
+    cv.Optional("cover"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(cover.Cover), cv.Optional("meta") : ACCESSORY_INFORMATION}),
     cv.Optional("climate"):  cv.ensure_list({cv.Required(CONF_ID): cv.use_id(climate.Climate), cv.Optional("meta") : ACCESSORY_INFORMATION}),
 }).extend(cv.COMPONENT_SCHEMA),
 cv.only_on_esp32)
@@ -139,6 +141,14 @@ async def to_code(config):
                 for m in l["meta"]:
                     info_temp.append([ACC_INFO[m], l["meta"][m]])
                 cg.add(switch_entity.setInfo(info_temp))
+    if "cover" in config:
+        for l in config["cover"]:
+            cover_entity = cg.Pvariable(ID(f"{l['id'].id}_hk_cover_entity", type=CoverEntity), var.add_cover(await cg.get_variable(l['id'])))
+            if "meta" in l:
+                info_temp = []
+                for m in l["meta"]:
+                    info_temp.append([ACC_INFO[m], l["meta"][m]])
+                cg.add(cover_entity.setInfo(info_temp))
     if "climate" in config:
         for l in config["climate"]:
             climate_entity = cg.Pvariable(ID(f"{l['id'].id}_hk_climate_entity", type=ClimateEntity), var.add_climate(await cg.get_variable(l['id'])))

--- a/components/homekit/cover.hpp
+++ b/components/homekit/cover.hpp
@@ -1,0 +1,136 @@
+#pragma once
+#include <esphome/core/defines.h>
+#ifdef USE_COVER
+#include <esphome/core/application.h>
+#include <hap.h>
+#include <hap_apple_servs.h>
+#include <hap_apple_chars.h>
+#include "hap_entity.h"
+
+namespace esphome
+{
+  namespace homekit
+  {
+    class CoverEntity : public HAPEntity
+    {
+    private:
+      static constexpr const char* TAG = "CoverEntity";
+      cover::Cover* coverPtr;
+      // HomeKit CurrentDoorState: 0 Open, 1 Closed, 2 Opening, 3 Closing, 4 Stopped
+      static uint8_t current_door_state(cover::Cover* obj) {
+        if (obj->current_operation == cover::COVER_OPERATION_OPENING) {
+          return 2;
+        }
+        if (obj->current_operation == cover::COVER_OPERATION_CLOSING) {
+          return 3;
+        }
+        if (obj->position >= 0.99f) {
+          return 0;
+        }
+        if (obj->position <= 0.01f) {
+          return 1;
+        }
+        return 4;
+      }
+      // HomeKit TargetDoorState: 0 Open, 1 Closed
+      static uint8_t target_door_state(cover::Cover* obj) {
+        uint8_t current = current_door_state(obj);
+        return (current == 1 || current == 3) ? 1 : 0;
+      }
+      static int cover_write(hap_write_data_t write_data[], int count, void* serv_priv, void* write_priv) {
+        cover::Cover* coverPtr = (cover::Cover*)serv_priv;
+        ESP_LOGD(TAG, "Write called for Accessory %s (%s)", std::to_string(coverPtr->get_object_id_hash()).c_str(), coverPtr->get_name().c_str());
+        int i, ret = HAP_SUCCESS;
+        hap_write_data_t* write;
+        for (i = 0; i < count; i++) {
+          write = &write_data[i];
+          if (!strcmp(hap_char_get_type_uuid(write->hc), HAP_CHAR_UUID_TARGET_DOOR_STATE)) {
+            ESP_LOGD(TAG, "Received Write for garage door '%s' -> %s", coverPtr->get_name().c_str(), write->val.i ? "Close" : "Open");
+            auto call = coverPtr->make_call();
+            if (write->val.i) {
+              call.set_command_close();
+            }
+            else {
+              call.set_command_open();
+            }
+            call.perform();
+            hap_char_update_val(write->hc, &(write->val));
+            *(write->status) = HAP_STATUS_SUCCESS;
+          }
+          else {
+            *(write->status) = HAP_STATUS_RES_ABSENT;
+          }
+        }
+        return ret;
+      }
+      static void on_cover_update(cover::Cover* obj) {
+        ESP_LOGD(TAG, "%s position: %.2f operation: %d", obj->get_name().c_str(), obj->position, (int)obj->current_operation);
+        hap_acc_t* acc = hap_acc_get_by_aid(hap_get_unique_aid(std::to_string(obj->get_object_id_hash()).c_str()));
+        if (acc) {
+          hap_serv_t* hs = hap_acc_get_serv_by_uuid(acc, HAP_SERV_UUID_GARAGE_DOOR_OPENER);
+          hap_char_t* current_state = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_CURRENT_DOOR_STATE);
+          hap_char_t* target_state = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_TARGET_DOOR_STATE);
+          hap_val_t c;
+          hap_val_t t;
+          c.i = current_door_state(obj);
+          t.i = target_door_state(obj);
+          hap_char_update_val(target_state, &t);
+          hap_char_update_val(current_state, &c);
+        }
+      }
+      static int acc_identify(hap_acc_t* ha) {
+        ESP_LOGI(TAG, "Accessory identified");
+        return HAP_SUCCESS;
+      }
+    public:
+      CoverEntity(cover::Cover* coverPtr) : HAPEntity({{MODEL, "HAP-GARAGE"}}), coverPtr(coverPtr) {}
+      void setup() {
+        hap_acc_cfg_t acc_cfg = {
+            .model = strdup(accessory_info[MODEL]),
+            .manufacturer = strdup(accessory_info[MANUFACTURER]),
+            .fw_rev = strdup(accessory_info[FW_REV]),
+            .hw_rev = NULL,
+            .pv = strdup("1.1.0"),
+            .cid = HAP_CID_BRIDGE,
+            .identify_routine = acc_identify,
+        };
+        hap_acc_t* accessory = nullptr;
+        hap_serv_t* service = nullptr;
+        std::string accessory_name = coverPtr->get_name();
+        if (accessory_info[NAME] == NULL) {
+          acc_cfg.name = strdup(accessory_name.c_str());
+        }
+        else {
+          acc_cfg.name = strdup(accessory_info[NAME]);
+        }
+        if (accessory_info[SN] == NULL) {
+          acc_cfg.serial_num = strdup(std::to_string(coverPtr->get_object_id_hash()).c_str());
+        }
+        else {
+          acc_cfg.serial_num = strdup(accessory_info[SN]);
+        }
+        /* Create accessory object */
+        accessory = hap_acc_create(&acc_cfg);
+        /* Create the Garage Door Opener Service. ObstructionDetected is required
+         * by HAP but has no ESPHome feed yet, so it always reports false. */
+        service = hap_serv_garage_door_opener_create(current_door_state(coverPtr), target_door_state(coverPtr), false);
+
+        ESP_LOGD(TAG, "ID HASH: %lu", coverPtr->get_object_id_hash());
+        hap_serv_set_priv(service, coverPtr);
+
+        /* Set the write callback for the service */
+        hap_serv_set_write_cb(service, cover_write);
+
+        /* Add the Garage Door Opener Service to the Accessory Object */
+        hap_acc_add_serv(accessory, service);
+
+        /* Add the Accessory to the HomeKit Database */
+        hap_add_bridged_accessory(accessory, hap_get_unique_aid(std::to_string(coverPtr->get_object_id_hash()).c_str()));
+        if (!coverPtr->is_internal())
+          coverPtr->add_on_state_callback([this]() { CoverEntity::on_cover_update(coverPtr); });
+        ESP_LOGI(TAG, "Cover '%s' linked to HomeKit as Garage Door Opener", accessory_name.c_str());
+      }
+    };
+  }
+}
+#endif


### PR DESCRIPTION
## Summary

Adds a `cover` entity type to the `homekit` component, exposing ESPHome cover entities as HomeKit **Garage Door Opener** accessories via `hap_serv_garage_door_opener_create`.

- New `components/homekit/cover.hpp` — `CoverEntity` modeled closely on `switch.hpp`
- `TargetDoorState` writes (0 = Open, 1 = Closed) invoke `cover->make_call().set_command_open()/close().perform()`
- The cover's state callback maps `current_operation`/`position` to `CurrentDoorState` (Open/Closed/Opening/Closing/Stopped) and keeps `TargetDoorState` consistent so the Home app shows Opening…/Closing… correctly
- `ObstructionDetected` is currently always `false` — there is no generic ESPHome source for it; it could later be wired to an optional `binary_sensor`
- Registration follows the existing pattern: `HAPAccessory.h/.cpp` + `cover:` entry in the config schema with the usual optional `meta`

## Usage

```yaml
cover:
  - platform: template   # any cover platform
    id: my_door

homekit:
  cover:
    - id: my_door
```

## Design note

The mapping is hardcoded to Garage Door Opener, which fits gates/garage doors (`device_class: gate/garage`). If you'd prefer, this could branch on the cover's `device_class` and use `hap_serv_window_covering_create` for blinds/shades — happy to extend the PR that way.

## Testing

- Compiles and links with ESPHome 2026.2.4 + ESP-IDF 5.5.2 on `esp32dev` (ESP32-WROOM-32E), alongside `api` and `web_server`
- Config schema also validates on ESPHome 2026.6.5
- Target hardware is a Nice MC800 swing gate driven by a custom cover component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HomeKit support for ESPHome covers.
  * Covers appear as Garage Door Opener accessories with current and target door states.
  * HomeKit commands can open and close connected covers.
  * Cover accessory metadata and state updates are supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->