### PR TITLE
Fix ESP-IDF build: declare espressif/libsodium dependency + const mismatch

### DIFF
--- a/components/homekit_base/HAPRootComponent.cpp
+++ b/components/homekit_base/HAPRootComponent.cpp
@@ -27,7 +27,7 @@ namespace esphome
 
         HAPRootComponent::HAPRootComponent(const char* setup_code, const char* setup_id, std::map<AInfo, const char*> info)
         {
-          const struct randombytes_implementation randombytes_esp32_implementation = {
+          struct randombytes_implementation randombytes_esp32_implementation = {
               .implementation_name = randombytes_esp32xx_implementation_name,
               .random = esp_random,
               .stir = NULL,

--- a/components/homekit_base/__init__.py
+++ b/components/homekit_base/__init__.py
@@ -48,7 +48,20 @@ cv.only_on_esp32)
 
 async def to_code(config):
     if getattr(CORE, "using_toolchain_esp_idf", False):
+        # Under Arduino, ESPHome already bundles its own libsodium port
+        # (used for API Noise encryption), so pulling in another one would
+        # cause duplicate-symbol conflicts - hence lib_ignore for Arduino.
+        # Under ESP-IDF there is no such bundled libsodium, and unlike a
+        # git-based add_idf_component() dependency (like the esp_hap_*
+        # components below), this one must come from the ESP-IDF Component
+        # Registry so its CMakeLists.txt declares itself as a proper
+        # REQUIRES/PRIV_REQUIRES target - which is what makes
+        # "sodium/randombytes.h" resolvable from HAPRootComponent.cpp.
         cg.add_platformio_option("lib_ignore", ["libsodium"])
+        add_idf_component(
+            name="espressif/libsodium",
+            ref="1.0.20",
+        )
     add_idf_component(
         name="esp_hap_core",
         repo="https://github.com/rednblkx/esp-homekit-sdk",


### PR DESCRIPTION
## Description

Fixes #68

Building any config with `homekit_base` on `framework: type: esp-idf`
currently fails. This PR fixes two separate issues found while tracking
that down.

### 1. Missing ESP-IDF Component Registry dependency

`HAPRootComponent.cpp` includes `sodium/randombytes.h`, which is provided
by the `espressif/libsodium` ESP-IDF Component Registry package. That
dependency was never declared anywhere in the project for the ESP-IDF case
- only `cg.add_platformio_option("lib_ignore", ["libsodium"])` existed,
which is a PlatformIO/Arduino-only option and has no effect under ESP-IDF.
Without a declared dependency, ESP-IDF's stricter component isolation
(`REQUIRES`/`PRIV_REQUIRES`) refuses to resolve the header, failing with:

```
fatal error: sodium/randombytes.h: No such file or directory
```

Fixed by registering it the same way the existing `esp_hap_core` /
`esp_hap_apple_profiles` / `esp_hap_extras` dependencies are registered in
this file, just pointing at the ESP-IDF Component Registry instead of a
git repo:

```python
add_idf_component(
    name="espressif/libsodium",
    ref="1.0.20",
)
```

### 2. const mismatch against the resolved libsodium API

Once the header actually resolves, `HAPRootComponent.cpp` fails to compile
with:

```
error: invalid conversion from 'const randombytes_implementation*' to
'randombytes_implementation*' [-fpermissive]
```

`randombytes_set_implementation()` in `espressif/libsodium@1.0.20` takes a
non-const `randombytes_implementation*`, but the local struct was declared
`const`. The struct is only used locally and passed straight to the
setter, so dropping `const` has no functional side effects.

## Testing

- Confirmed the original error (`sodium/randombytes.h: No such file or
  directory`) is fully reproducible on a clean config using only
  `homekit_base` + `homekit: light:` on ESP-IDF.
- Applied both fixes on top of `main` and ran a full `esphome compile`
  against a real project config (ESPHome 2026.8.1, ESP-IDF 5.5.5,
  `esp32dev` board) - build completes successfully with both fixes
  applied, fails at fix #1's spot without them, and fails at fix #2's spot
  with only fix #1 applied.

## Notes

- `ref="1.0.20"` was picked as a current stable release from the Component
  Registry; happy to change it if a different pinned version is preferred
  for this project.
- The Arduino/PlatformIO build path is untouched by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ESP-IDF build compatibility and reliability.
  * Updated the underlying cryptographic support used during ESP-IDF builds to ensure consistent results across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->